### PR TITLE
Add cmake flags for mac cross compiling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,9 +2,17 @@ use std::path::Path;
 use std::env;
 #[cfg(feature = "yaz0")]
 fn build_zlib() {
-    std::process::Command::new("cmake")
-        .current_dir("lib/zlib-ng")
-        .arg(".")
+    let target = env::var("TARGET").unwrap();
+    let mut cmake = std::process::Command::new("cmake");
+    cmake.current_dir("lib/zlib-ng");
+    if target.contains("aarch64-apple-darwin") {
+        cmake.arg("-DCMAKE_OSX_ARCHITECTURES=arm64");
+    } else if target.contains("x86_64-apple-darwin") {
+        cmake.arg("-DCMAKE_OSX_ARCHITECTURES=x86_64");
+    } else {
+        //Not OSX
+    }
+    cmake.arg(".")
         .output()
         .expect("Failed to build zlib. Is CMake installed?");
     std::process::Command::new("cmake")


### PR DESCRIPTION
Finish work for https://github.com/NiceneNerd/ukmm/issues/119. For macOS targets, this adds appropriate `-DCMAKE_OSX_ARCHITECTURES` flags dependent on the target architecture. This is useful if we ever want to build an M1 native or universal binary for a release