### PR TITLE
Fix ARM64 macOS building

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,9 @@ fn build_zlib() {
     let mut cmake = std::process::Command::new("cmake");
     cmake.current_dir("lib/zlib-ng");
     if target.contains("aarch64-apple-darwin") {
-        cmake.arg("-DCMAKE_OSX_ARCHITECTURES=arm64");
+        cmake
+		.arg("-DCMAKE_OSX_ARCHITECTURES=arm64")
+        	.arg("-DWITH_NEON=OFF");
     } else if target.contains("x86_64-apple-darwin") {
         cmake.arg("-DCMAKE_OSX_ARCHITECTURES=x86_64");
     } else {

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn build_zlib() {
     cmake.current_dir("lib/zlib-ng");
     if target.contains("aarch64-apple-darwin") {
         cmake
-		.arg("-DCMAKE_OSX_ARCHITECTURES=arm64")
+			.arg("-DCMAKE_OSX_ARCHITECTURES=arm64")
         	.arg("-DWITH_NEON=OFF");
     } else if target.contains("x86_64-apple-darwin") {
         cmake.arg("-DCMAKE_OSX_ARCHITECTURES=x86_64");


### PR DESCRIPTION
Fixes #12. This adds the flag "WITH_NEON=OFF" to the zlib cmake command. Building with NEON enabled triggers the following:

```
if(BASEARCH_ARM_FOUND)
    # Check support for ARM floating point
    execute_process(COMMAND ${CMAKE_C_COMPILER} "-dumpmachine"
                    OUTPUT_VARIABLE GCC_MACHINE)
    if ("${GCC_MACHINE}" MATCHES "eabihf")
        set(FLOATABI "-mfloat-abi=hard")
    else()
        set(FLOATABI "-mfloat-abi=softfp")
    endif()
    # NEON
    if("${ARCH}" MATCHES "aarch64")
        set(NEONFLAG "-march=armv8-a+crc+simd")
    else()
        # Check whether -mfpu=neon is available
        set(CMAKE_REQUIRED_FLAGS "-mfpu=neon")
        check_c_source_compiles(
            "int main() { return 0; }"
            MFPU_NEON_AVAILABLE FAIL_REGEX "not supported")
        set(CMAKE_REQUIRED_FLAGS)
        if(MFPU_NEON_AVAILABLE)
            set(NEONFLAG "${FLOATABI} -mfpu=neon")
        else()
            set(NEONFLAG "${FLOATABI}")
        endif()
    endif()
    # ACLE
    set(ACLEFLAG "-march=armv8-a+crc")
elseif(BASEARCH_X86_FOUND)
    set(AVX2FLAG "-mavx2")
    set(SSE2FLAG "-msse2")
    set(SSE4FLAG "-msse4")
    set(PCLMULFLAG "-mpclmul")
endif()
```

So if NEON is enabled, -mfloat-abi is used, which isn't supported.

```
clang: error: unsupported option '-mfloat-abi=' for target 'arm64-apple-darwin25.4.0'
make[2]: *** [CMakeFiles/zlib.dir/adler32.c.o] Error 1
make[1]: *** [CMakeFiles/zlib.dir/all] Error 2
make: *** [all] Error 2
```